### PR TITLE
Added a timezone variable to the .env file

### DIFF
--- a/.env
+++ b/.env
@@ -33,3 +33,7 @@ CACHE_MEM_SIZE=500m
 
 ## Change this to limit the maximum age of cached content (default 3650d)
 CACHE_MAX_AGE=3650d
+
+## Set the timezone for the docker containers, useful for correct timestamps on logs (default Europe/London)
+## Formatted as tz database names. Example: Europe/Oslo or America/Los_Angeles
+TZ=Europe/London

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ This setting allows you to control the maximum duration cached data will be kept
 
 > **Note:** this must be given as a number of days in age before expiry, with a `d` suffix (e.g. the default value, `3650d`).
 
+## `TZ`
+This setting allows you to set the timezone that is used by the docker containers. Most notably changing the timestamps of the logs. Useful for debugging without having to think sometimes multiple hours in the future/past. 
+
+For a list of all timezones see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
+
 # More information
 The LanCache docker-stack is generated automatically from the data over at [UKLans](https://github.com/uklans/cache-domains). All services that are listed in the UKLans repository are available and supported inside this docker-compose.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,16 @@ services:
 #    restart: unless-stopped
     ports:
       - ${DNS_BIND_IP}:53:53/udp
+    environment:
+      - TZ=${TZ}
   sniproxy:
     image: lancachenet/sniproxy:latest
     env_file: .env
 #    restart: unless-stopped
     ports:
       - 443:443/tcp
+    environment:
+      - TZ=${TZ}
   monolithic:
     image: lancachenet/monolithic:latest
     env_file: .env
@@ -21,3 +25,5 @@ services:
     volumes:
       - ${CACHE_ROOT}/cache:/data/cache
       - ${CACHE_ROOT}/logs:/data/logs
+    environment:
+      - TZ=${TZ}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,5 +28,3 @@ services:
     volumes:
       - ${CACHE_ROOT}/cache:/data/cache
       - ${CACHE_ROOT}/logs:/data/logs
-    environment:
-      - TZ=${TZ}


### PR DESCRIPTION
As the title says, added a variable to edit the timezone of the docker containers as well as changed docker-compose.yml to use the timezone value set in .env.
~~Might want to update README.md as well, but I haven't done that.~~ 
**EDIT**: Added documentation as well

Tested and everything seems to work perfectly.