### PR TITLE
Remove sniproxy from main docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,18 +7,19 @@ services:
     ports:
       - ${DNS_BIND_IP}:53:53/udp
       - ${DNS_BIND_IP}:53:53/tcp
-  sniproxy:
-    image: lancachenet/sniproxy:latest
-    env_file: .env
+#  sniproxy:
+#    image: lancachenet/sniproxy:latest
+#    env_file: .env
 #    restart: unless-stopped
-    ports:
-      - 443:443/tcp
+#    ports:
+#      - 443:443/tcp
   monolithic:
-    image: lancachenet/monolithic:latest
+    image: lancachenet/monolithic:stream
     env_file: .env
 #    restart: unless-stopped
     ports:
       - 80:80/tcp
+      - 443:443/tcp
     volumes:
       - ${CACHE_ROOT}/cache:/data/cache
       - ${CACHE_ROOT}/logs:/data/logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 #      - 443:443/tcp
 
   monolithic:
-    image: lancachenet/monolithic:stream
+    image: lancachenet/monolithic:latest
     env_file: .env
 #    restart: unless-stopped
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,17 @@ services:
     ports:
       - ${DNS_BIND_IP}:53:53/udp
       - ${DNS_BIND_IP}:53:53/tcp
+
+## HTTPS requests are now handled in monolithic directly
+## you could choose to return to sniproxy if desired
+#
 #  sniproxy:
 #    image: lancachenet/sniproxy:latest
 #    env_file: .env
 #    restart: unless-stopped
 #    ports:
 #      - 443:443/tcp
+
   monolithic:
     image: lancachenet/monolithic:stream
     env_file: .env

--- a/update_containers.sh
+++ b/update_containers.sh
@@ -2,4 +2,4 @@
 
 
 docker-compose pull
-docker-compose up -d
+docker-compose up -d --remove-orphans


### PR DESCRIPTION
This is the final stage of https://github.com/lancachenet/generic/pull/107 and will roll over removing sniproxy from the majority of use cases.

