### PR TITLE
.env: Change CACHE_DISK_SIZE to be in gigabyte (g)

### DIFF
--- a/.env
+++ b/.env
@@ -19,15 +19,15 @@ UPSTREAM_DNS=8.8.8.8
 ## Note that by default, this will be a folder relative to the docker-compose.yml file
 CACHE_ROOT=./lancache
 
-## Change this to customise the size of the disk cache (default 2000000m)
+## Change this to customise the size of the disk cache (default 2000g)
 ## If you have more storage, you'll likely want to increase this
 ## The cache server will prune content on a least-recently-used basis if it
 ## starts approaching this limit.
-## Set this to a little bit less than your actual available space 
-CACHE_DISK_SIZE=2000000m
+## Set this to a little bit less than your actual available space
+CACHE_DISK_SIZE=2000g
 
 ## Change this to allow sufficient index memory for the nginx cache manager (default 500m)
-## We recommend 250m of index memory per 1TB of CACHE_DISK_SIZE 
+## We recommend 250m of index memory per 1TB of CACHE_DISK_SIZE
 CACHE_INDEX_SIZE=500m
 
 ## Change this to limit the maximum age of cached content (default 3650d)


### PR DESCRIPTION
`g` or `G` are both valid values for the `max_size` parameter since this is considered an `offset value` in the nginx code. I think this is a bit clearer then a `2000000m` value :)

See:
https://github.com/nginx/nginx/blob/master/src/http/ngx_http_file_cache.c#L2490
https://github.com/nginx/nginx/blob/master/src/core/ngx_parse.c#L59

This change ran in production on the latest version of [lancachenet/docker-compose](https://github.com/lancachenet/docker-compose) during Frag-o-Matic 23.0 (2-4 September 2022)

Related PR: https://github.com/lancachenet/monolithic/pull/151