### PR TITLE
Changing CACHE_DISK_SIZE to use the 'g' suffix instead of 'm', as dis…

### DIFF
--- a/.env
+++ b/.env
@@ -19,12 +19,12 @@ UPSTREAM_DNS=8.8.8.8
 ## Note that by default, this will be a folder relative to the docker-compose.yml file
 CACHE_ROOT=./lancache
 
-## Change this to customise the size of the disk cache (default 2000000m)
+## Change this to customise the size of the disk cache (default 2000g)
 ## If you have more storage, you'll likely want to increase this
 ## The cache server will prune content on a least-recently-used basis if it
 ## starts approaching this limit.
 ## Set this to a little bit less than your actual available space 
-CACHE_DISK_SIZE=2000000m
+CACHE_DISK_SIZE=2000g
 
 ## Change this to allow sufficient index memory for the nginx cache manager (default 500m)
 ## We recommend 250m of index memory per 1TB of CACHE_DISK_SIZE 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ This setting will constrain the upper limit of space used by cached data. You ge
 
 The cache server will automatically delete cached data when the total stored amount approaches this limit, in a least-recently-used fashion (oldest data, least accessed deleted first).
 
-> **Note:** that this must be given in gigabytes with a `g` suffix (e.g. the default value, `2000g`).
+> **Note:** that this must be given in either:
+> - gigabytes, with `g` suffix (e.g. the default value, `1000g`)
+> - megabytes, with `m` suffix (e.g. `900000m`)
 
 ## `CACHE_INDEX_SIZE`
 Change this to allow sufficient index memory for the nginx cache manager (default 500m)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This setting will constrain the upper limit of space used by cached data. You ge
 
 The cache server will automatically delete cached data when the total stored amount approaches this limit, in a least-recently-used fashion (oldest data, least accessed deleted first).
 
-> **Note:** that this must be given in megabytes with an `m` suffix (e.g. the default value, `1000000m`).
+> **Note:** that this must be given in gigabytes with a `g` suffix (e.g. the default value, `2000g`).
 
 ## `CACHE_INDEX_SIZE`
 Change this to allow sufficient index memory for the nginx cache manager (default 500m)


### PR DESCRIPTION
…k sizes are generally in the terabyte range now.