### PR TITLE
chore: update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 x-restart-policy: &restart-policy "no"
 services:
   dns:


### PR DESCRIPTION
Just a small update to the `docker-compose.yml` to reflect the recent changes in Docker v25. 

The `Version` top-level element is now obsolete and users will get a warning about it: 

`WARN[0000] /lancache/docker-compose.yml: `version` is obsolete` 

It still works, but new users might get confused about the warning they don't expect. 

To test this change simply clone the repo to a host running docker v25 or newer and deploy lancache as usual. There shouldn't be any warning about the deprecated config. 

