### PR TITLE
Adding support for NGINX's min_free variable

### DIFF
--- a/.cspell.config.json
+++ b/.cspell.config.json
@@ -1,0 +1,19 @@
+// cSpell Settings
+{
+    "version": "0.2",
+    "language": "en-GB",
+
+    "dictionaries": [
+        // Makes cSpell only use the British spelling of words
+        "!en_US"
+    ],
+    // List of words to be always considered correct
+    "words": [
+    ],
+    // List of words to be always considered incorrect
+    // This is useful for offensive words and common spelling errors.
+    // For example "hte" should be "the"
+    "flagWords": [
+        "hte"
+    ]
+}

--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@
 USE_GENERIC_CACHE=true
 
 ## IP addresses that the lancache monolithic instance is reachable on
-## Specify one or more IPs, space separated - these will be used when colour resolving DNS hostnames through lancachenet-dns. Multiple IPs can improve cache priming performance for some services (e.g. Steam)
+## Specify one or more IPs, space separated - these will be used when resolving DNS hostnames through lancachenet-dns. Multiple IPs can improve cache priming performance for some services (e.g. Steam)
 ## Note: This setting only affects DNS, monolithic and sniproxy will still bind to all IPs by default
 LANCACHE_IP=10.0.39.1
 

--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 ## See the "Settings" section in README.md for more details
 
-## Set this to true if you're using a load balancer, or set it to false if you're using seperate IPs for each service.
+## Set this to true if you're using a load balancer, or set it to false if you're using separate IPs for each service.
 ## If you're using monolithic (the default), leave this set to true
 USE_GENERIC_CACHE=true
 
@@ -19,15 +19,20 @@ UPSTREAM_DNS=8.8.8.8
 ## Note that by default, this will be a folder relative to the docker-compose.yml file
 CACHE_ROOT=./lancache
 
-## Change this to customise the size of the disk cache (default 2000g)
+## Change this to customize the size of the disk cache (default 2000g)
 ## If you have more storage, you'll likely want to increase this
 ## The cache server will prune content on a least-recently-used basis if it
 ## starts approaching this limit.
-## Set this to a little bit less than your actual available space 
+## Set this to a little bit less than your actual available space
 CACHE_DISK_SIZE=2000g
 
+## Sets the minimum free disk space that must be kept at all times.
+## When the available free space drops below the set amount for any reason, the cache server will begin
+## pruning content to free up space.
+MIN_FREE_DISK=100g
+
 ## Change this to allow sufficient index memory for the nginx cache manager (default 500m)
-## We recommend 250m of index memory per 1TB of CACHE_DISK_SIZE 
+## We recommend 250m of index memory per 1TB of CACHE_DISK_SIZE
 CACHE_INDEX_SIZE=500m
 
 ## Change this to limit the maximum age of cached content (default 3650d)

--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@
 USE_GENERIC_CACHE=true
 
 ## IP addresses that the lancache monolithic instance is reachable on
-## Specify one or more IPs, space separated - these will be used when resolving DNS hostnames through lancachenet-dns. Multiple IPs can improve cache priming performance for some services (e.g. Steam)
+## Specify one or more IPs, space separated - these will be used when colour resolving DNS hostnames through lancachenet-dns. Multiple IPs can improve cache priming performance for some services (e.g. Steam)
 ## Note: This setting only affects DNS, monolithic and sniproxy will still bind to all IPs by default
 LANCACHE_IP=10.0.39.1
 
@@ -19,17 +19,17 @@ UPSTREAM_DNS=8.8.8.8
 ## Note that by default, this will be a folder relative to the docker-compose.yml file
 CACHE_ROOT=./lancache
 
-## Change this to customize the size of the disk cache (default 2000g)
-## If you have more storage, you'll likely want to increase this
+## Change this to customise the maximum size of the disk cache (default 2000g).
+## If you have more storage, you'll likely want to increase this.
 ## The cache server will prune content on a least-recently-used basis if it
 ## starts approaching this limit.
-## Set this to a little bit less than your actual available space
 CACHE_DISK_SIZE=2000g
 
 ## Sets the minimum free disk space that must be kept at all times.
-## When the available free space drops below the set amount for any reason, the cache server will begin
-## pruning content to free up space.
-MIN_FREE_DISK=100g
+## When the available free space drops below the set amount for any reason,
+## the cache server will begin pruning content to free up space.
+## Prevents accidentally running out of disk space if CACHE_DISK_SIZE is set too high.
+MIN_FREE_DISK=10g
 
 ## Change this to allow sufficient index memory for the nginx cache manager (default 500m)
 ## We recommend 250m of index memory per 1TB of CACHE_DISK_SIZE

--- a/README.md
+++ b/README.md
@@ -53,12 +53,11 @@ The `CACHE_ROOT` should either be on a separate partition, or ideally on separat
 > **Note:** this setting defaults to `./lancache`. Unless your cache storage lives here, you probably want to change this value.
 
 ## `CACHE_DISK_SIZE`
-This setting will constrain the upper limit of space used by cached data. You generally want to leave a small gap (10-20GB at least) between the size listed here and the available storage space used for the cached data, just in case.
-
+This setting will constrain the upper limit of space used by cached data.
 The cache server will automatically delete cached data when the total stored amount approaches this limit, in a least-recently-used fashion (oldest data, least accessed deleted first).
 
 > **Note:** that this must be given in either:
-> - gigabytes, with `g` suffix (e.g. the default value, `1000g`)
+> - gigabytes, with `g` suffix (e.g. the default value, `2000g`)
 > - terabytes, with `t` suffix (e.g. `4t`)
 
 ## `MIN_FREE_DISK`

--- a/README.md
+++ b/README.md
@@ -59,11 +59,16 @@ The cache server will automatically delete cached data when the total stored amo
 
 > **Note:** that this must be given in either:
 > - gigabytes, with `g` suffix (e.g. the default value, `1000g`)
-> - megabytes, with `m` suffix (e.g. `900000m`)
+> - terabytes, with `t` suffix (e.g. `4t`)
+
+## `MIN_FREE_DISK`
+Configures the minimum amount of free disk space that must be kept at all times.  This setting avoids the scenario where the disk can accidentally become completely full, and no further data can be written.
+
+When the available free space drops below the set amount for any reason, the cache server will begin pruning content in a least-recently-used fashion, similar to how `CACHE_DISK_SIZE` works.
 
 ## `CACHE_INDEX_SIZE`
 Change this to allow sufficient index memory for the nginx cache manager (default 500m)
-We recommend 250m of index memory per 1TB of CACHE_DISK_SIZE 
+We recommend 250m of index memory per 1TB of CACHE_DISK_SIZE
 
 > **Note:** this setting does not limit the amount of memory that the Linux host will use for page caches, only what the cache server will use itself - see the Docker documentation on limiting memory consumption for a container if you wish to constrain the total memory consumption of the cache server, but generally you want as much memory as possible on your cache server to be used to store hot data.
 
@@ -73,7 +78,7 @@ This setting allows you to control the maximum duration cached data will be kept
 > **Note:** this must be given as a number of days in age before expiry, with a `d` suffix (e.g. the default value, `3650d`).
 
 ## `TZ`
-This setting allows you to set the timezone that is used by the docker containers. Most notably changing the timestamps of the logs. Useful for debugging without having to think sometimes multiple hours in the future/past. 
+This setting allows you to set the timezone that is used by the docker containers. Most notably changing the timestamps of the logs. Useful for debugging without having to think sometimes multiple hours in the future/past.
 
 For a list of all timezones see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
 


### PR DESCRIPTION
See parent issue [lancachenet/monolithic - Implement NGINX 'min_free` parameter to ensure cache drive always has free space](https://github.com/lancachenet/monolithic/issues/190)